### PR TITLE
✨ Adds CreatedAt and UpdatedAt to Entity and AggregateRoot

### DIFF
--- a/src/TheNoobs.AggregateRoot/AggregateRoot.cs
+++ b/src/TheNoobs.AggregateRoot/AggregateRoot.cs
@@ -59,6 +59,25 @@ public abstract class AggregateRoot<TId, TExternalId> : Entity<TId, TExternalId>
     }
     
     /// <summary>
+    /// Initializes a new instance, explicitly setting an identification and creation timestamp.
+    /// </summary>
+    /// <param name="id">Entity identification.</param>
+    /// <param name="createdAt">Entity creation timestamp.</param>
+    protected AggregateRoot(TId id, DateTimeOffset createdAt) : base(id, createdAt)
+    {
+    }
+    
+    /// <summary>
+    /// Initializes a new instance, explicitly setting identification, external identification and creation timestamp.
+    /// </summary>
+    /// <param name="id">Entity identification.</param>
+    /// <param name="externalId">Entity external identification.</param>
+    /// <param name="createdAt">Entity creation timestamp.</param>
+    protected AggregateRoot(TId id, TExternalId externalId, DateTimeOffset createdAt) : base(id, externalId, createdAt)
+    {
+    }
+    
+    /// <summary>
     /// Initializes a new instance, explicitly setting both identification and external identification.
     /// </summary>
     /// <param name="id">Aggregate root identification.</param>

--- a/src/TheNoobs.AggregateRoot/Entity.cs
+++ b/src/TheNoobs.AggregateRoot/Entity.cs
@@ -13,12 +13,23 @@ public abstract class Entity<TId> : IEquatable<Entity<TId>> where TId : IEquatab
     #endif
     
     /// <summary>
-    /// Initializes a new instance, explicitly setting an identification.
+    /// Initializes a new instance, explicitly setting an identification and creation timestamp.
     /// </summary>
     /// <param name="id">Entity identification.</param>
-    protected Entity(TId id)
+    /// <param name="createdAt">Entity creation timestamp.</param>
+    protected Entity(TId id, DateTimeOffset createdAt)
     {
         Id = id;
+        CreatedAt = UpdatedAt = createdAt;
+    }
+    
+    /// <summary>
+    /// Initializes a new instance, explicitly setting an identification.
+    /// The creation date will be set to UTC now.
+    /// </summary>
+    /// <param name="id">Entity identification.</param>
+    protected Entity(TId id) : this(id, DateTimeOffset.UtcNow)
+    {
     }
 
     /// <summary>
@@ -32,6 +43,26 @@ public abstract class Entity<TId> : IEquatable<Entity<TId>> where TId : IEquatab
     /// Get Identification.
     /// </summary>
     public TId Id { get; private set; }
+    
+    public DateTimeOffset CreatedAt { get; private set; }
+    
+    public DateTimeOffset UpdatedAt { get; private set; }
+    
+    /// <summary>
+    /// Sets updated at to UTC now.
+    /// </summary>
+    public void SetUpdatedAtToUtcNow()
+    {
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    /// <summary>
+    /// Sets updated at to now (using the computer's local time zone).
+    /// </summary>
+    public void SetUpdatedAtToNow()
+    {
+        UpdatedAt = DateTimeOffset.Now;
+    }
 
     /// <summary>
     /// Compare current entity to another entity.
@@ -159,12 +190,33 @@ public abstract class Entity<TId, TExternalId> : Entity<TId>
     }
 
     /// <summary>
+    /// Initializes a new instance, explicitly setting an identification and creation timestamp.
+    /// </summary>
+    /// <param name="id">Entity identification.</param>
+    /// <param name="createdAt">Entity creation timestamp.</param>
+    protected Entity(TId id, DateTimeOffset createdAt) : base(id, createdAt)
+    {
+        InitializeExternalId();
+    }
+
+    /// <summary>
     /// Initializes a new instance, explicitly setting an identification.
     /// </summary>
     /// <param name="id">Entity identification.</param>
     protected Entity(TId id) : base(id)
     {
         InitializeExternalId();
+    }
+    
+    /// <summary>
+    /// Initializes a new instance, explicitly setting identification, external identification and creation timestamp.
+    /// </summary>
+    /// <param name="id">Entity identification.</param>
+    /// <param name="externalId">Entity external identification.</param>
+    /// <param name="createdAt">Entity creation timestamp.</param>
+    protected Entity(TId id, TExternalId externalId, DateTimeOffset createdAt) : base(id, createdAt)
+    {
+        ExternalId = externalId;
     }
 
     /// <summary>

--- a/tests/TheNoobs.AggregateRoot.UnitTests/EntityTests.cs
+++ b/tests/TheNoobs.AggregateRoot.UnitTests/EntityTests.cs
@@ -8,6 +8,59 @@ namespace TheNoobs.AggregateRoot.UnitTests;
 [Trait("Class", "Entity")]
 public class EntityTests
 {
+    [Fact(DisplayName = @"GIVEN an Entity, SHOULD set created at to UTC now")]
+    public void Given_entity_should_set_created_at_to_utc_now()
+    {
+        var person = new Person("Name of person");
+
+        person.CreatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMilliseconds(100));
+    }
+    
+    [Fact(DisplayName = @"GIVEN an Entity, SHOULD set updated at to UTC now")]
+    public void Given_entity_should_set_updated_at_to_utc_now()
+    {
+        var person = new Person("Name of person");
+
+        person.UpdatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMilliseconds(100));
+    }
+
+    [Fact(DisplayName = @"GIVEN an Entity and created at, SHOULD store in created at and updated at")]
+    public void Given_entity_and_created_at_should_store_in_created_at_and_updated_at()
+    {
+        var createdAt = DateTimeOffset.UtcNow;
+        
+        var person = new Person(1, "Name of person", createdAt);
+
+        person.CreatedAt.Should().Be(createdAt);
+        person.UpdatedAt.Should().Be(createdAt);
+    }
+    
+    [Fact(DisplayName = @"GIVEN an Entity, SHOULD be able to set updated at to now")]
+    public void Given_entity_should_be_able_to_set_updated_at_to_now()
+    {
+        var createdAt = DateTimeOffset.MinValue;
+        
+        var person = new Person(1, "Name of person", createdAt);
+
+        person.SetUpdatedAtToNow();
+        
+        person.UpdatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMilliseconds(100));
+        person.CreatedAt.Should().Be(createdAt);
+    }
+    
+    [Fact(DisplayName = @"GIVEN an Entity, SHOULD be able to set updated at to now")]
+    public void Given_entity_should_be_able_to_set_updated_at_to_utc_now()
+    {
+        var createdAt = DateTimeOffset.MinValue;
+        
+        var person = new Person(1, "Name of person", createdAt);
+
+        person.SetUpdatedAtToUtcNow();
+        
+        person.UpdatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMilliseconds(100));
+        person.CreatedAt.Should().Be(createdAt);
+    }
+    
     [Theory(DisplayName = @"GIVEN an Entity, SHOULD instantiate")]
     [InlineData(1, "Name of the first person")]
     [InlineData(2, "Name of the second person")]

--- a/tests/TheNoobs.AggregateRoot.UnitTests/Stubs/Person.cs
+++ b/tests/TheNoobs.AggregateRoot.UnitTests/Stubs/Person.cs
@@ -7,6 +7,11 @@ public class Person : AggregateRoot<long, Guid>
         Name = name;
     }
 
+    public Person(long id, string name, DateTimeOffset createdAt) : base(id, createdAt)
+    {
+        Name = name;
+    }
+
     public Person(string name)
     {
         Name = name;


### PR DESCRIPTION
# Description

With this Pull Request, I am proposing the addition of CreatedAt and UpdatedAt properties to Entity and AggregateRoot.

Since many solutions use those two columns as a way to audit databases and troubleshoot problems, this should be useful.

## Type of change

- [ ] :bug: Bug fix (non-breaking change which fixes an issue)
- [x] :sparkles: New feature (non-breaking change which adds functionality)
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] :memo: This change requires a documentation update

### How Has This Been Tested?

- [x] Checks if created at and updated at are set by default to UTC now at creation;
- [x] Allows manually setting created at (and updated at) to a specific date in a overloaded constructor;
- [x] Implements methods to set UpdatedAt to now or UTC now.

### Definition of Done

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Does this add new dependencies?
