### PR TITLE
Adjust equality operators to consider nullable variables in comparison

### DIFF
--- a/.devops/azuredevops.yml
+++ b/.devops/azuredevops.yml
@@ -25,7 +25,7 @@ resources:
       endpoint: thenoobsbr
       type: github
       name: TheNoobsBr/Azure-Templates
-      ref: refs/tags/2.4.1
+      ref: refs/tags/2.4.3
 
 variables:
   - template: variables.yml

--- a/src/TheNoobs.AggregateRoot/Entity.cs
+++ b/src/TheNoobs.AggregateRoot/Entity.cs
@@ -111,7 +111,7 @@ public abstract class Entity<TId> : IEquatable<Entity<TId>> where TId : IEquatab
     /// <param name="left">First value object.</param>
     /// <param name="right">Last value object.</param>
     /// <returns>True if <paramref name="left"/> is equal to <paramref name="right"/>.</returns>
-    public static bool operator ==(Entity<TId> left, Entity<TId> right)
+    public static bool operator ==(Entity<TId>? left, Entity<TId>? right)
     {
         if (ReferenceEquals(left, null) && ReferenceEquals(right, null)) return true;
         if (ReferenceEquals(left, null) || ReferenceEquals(right, null)) return false;
@@ -124,7 +124,7 @@ public abstract class Entity<TId> : IEquatable<Entity<TId>> where TId : IEquatab
     /// <param name="left">First value object.</param>
     /// <param name="right">Last value object.</param>
     /// <returns>True if <paramref name="left"/> is equal to <paramref name="right"/>.</returns>
-    public static bool operator !=(Entity<TId> left, Entity<TId> right)
+    public static bool operator !=(Entity<TId>? left, Entity<TId>? right)
     {
         return !(left == right);
     }

--- a/tests/TheNoobs.AggregateRoot.UnitTests/EntityTests.cs
+++ b/tests/TheNoobs.AggregateRoot.UnitTests/EntityTests.cs
@@ -53,6 +53,21 @@ public class EntityTests
 
         person.GetHashCode().Should().Be(id.GetHashCode());
     }
+    
+    [Fact(DisplayName = @"GIVEN an Entity, SHOULD be able to compare to nullable entity variable")]
+    public void Given_entity_variable_should_be_able_to_compare_to_nullable_entity_variable()
+    {
+        var person = new Person("Name of person");
+        Person? nullablePerson = null;
+        
+        (person == nullablePerson).Should().BeFalse();
+        (person != nullablePerson).Should().BeTrue();
+
+        nullablePerson = person;
+        
+        (person == nullablePerson).Should().BeTrue();
+        (person != nullablePerson).Should().BeFalse();
+    }
 
     [Theory(DisplayName = @"GIVEN entity, WHEN transient, SHOULD return base class hashcode")]
     [InlineData("Name 1")]


### PR DESCRIPTION
# Adjust equality operators to consider nullable variables in comparison

# Description

At the moment, whenever we try to compare two entities, when one of them is a nullable variable, the compiler emits a warning telling that the equality (or difference) operator can throw null reference exception because of the nullable side.

Even knowing that this is actually impossible because we are handling null values correctly in the operator, the warning still exists in the code.

To fix this, I propose to update the equality and difference operator to consider nullable variables in both sides of the comparison.

## Type of change

Please delete options that are not relevant.

- [ ] :bug: Bug fix (non-breaking change which fixes an issue)
- [x] :sparkles: New feature (non-breaking change which adds functionality)
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] :memo: This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] :white_check_mark: All tests were ran and new tests were added (if needed)

- [x] Test A: GIVEN an Entity, SHOULD be able to compare to nullable entity variable

### Attachments (if appropriate)

Add additional pieces of information like screenshots, issue links, etc.

### Definition of Done

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Does this add new dependencies?
